### PR TITLE
Update Kotlin dep to v1.7.10

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,8 +15,8 @@ buildscript {
 }
 
 plugins {
-    kotlin("jvm") version "1.6.0"
-    id("org.jetbrains.dokka") version "1.6.0"
+    kotlin("jvm") version "1.7.10"
+    id("org.jetbrains.dokka") version "1.7.10"
 }
 
 allprojects {


### PR DESCRIPTION
fixes #28 

~~Add properties to fix compatibility issues with newer KMM projects.~~
Update Kotlin dependency to 1.7.10 which comes with Hierarchical project structure by default. 

Reference: [Hierarchical project structure﻿](https://kotlinlang.org/docs/multiplatform-hierarchy.html)