### PR TITLE
Set unique android.namespaces for all the extensions

### DIFF
--- a/extensions/colormath-ext-android-color/build.gradle.kts
+++ b/extensions/colormath-ext-android-color/build.gradle.kts
@@ -31,7 +31,7 @@ kotlin {
 }
 
 android {
-    namespace = "com.github.ajalt.colormath"
+    namespace = "com.github.ajalt.colormath.extensions.android.color"
     compileSdk = 33
     defaultConfig.minSdk = 26 // Color instances were added in 26
 }

--- a/extensions/colormath-ext-android-color/build.gradle.kts
+++ b/extensions/colormath-ext-android-color/build.gradle.kts
@@ -34,4 +34,5 @@ android {
     namespace = "com.github.ajalt.colormath.extensions.android.color"
     compileSdk = 33
     defaultConfig.minSdk = 26 // Color instances were added in 26
+    buildFeatures.buildConfig = false
 }

--- a/extensions/colormath-ext-android-colorint/build.gradle.kts
+++ b/extensions/colormath-ext-android-colorint/build.gradle.kts
@@ -34,4 +34,5 @@ android {
     namespace = "com.github.ajalt.colormath.extensions.android.colorint"
     compileSdk = 33
     defaultConfig.minSdk = 21
+    buildFeatures.buildConfig = false
 }

--- a/extensions/colormath-ext-android-colorint/build.gradle.kts
+++ b/extensions/colormath-ext-android-colorint/build.gradle.kts
@@ -31,7 +31,7 @@ kotlin {
 }
 
 android {
-    namespace = "com.github.ajalt.colormath"
+    namespace = "com.github.ajalt.colormath.extensions.android.colorint"
     compileSdk = 33
     defaultConfig.minSdk = 21
 }

--- a/extensions/colormath-ext-jetpack-compose/build.gradle.kts
+++ b/extensions/colormath-ext-jetpack-compose/build.gradle.kts
@@ -39,7 +39,7 @@ kotlin {
 }
 
 android {
-    namespace = "com.github.ajalt.colormath"
+    namespace = "com.github.ajalt.colormath.extensions.android.composecolor"
     compileSdk = 33
     defaultConfig.minSdk = 21
 }

--- a/extensions/colormath-ext-jetpack-compose/build.gradle.kts
+++ b/extensions/colormath-ext-jetpack-compose/build.gradle.kts
@@ -42,6 +42,7 @@ android {
     namespace = "com.github.ajalt.colormath.extensions.android.composecolor"
     compileSdk = 33
     defaultConfig.minSdk = 21
+    buildFeatures.buildConfig = false
 }
 
 // workaround for https://github.com/Kotlin/dokka/issues/1833


### PR DESCRIPTION
these values are what were originally set in the `AndroidManifest.xml`. It doesn't matter too much what they are set to, just as long as they are unique and don't collide with other namespaces

Fixes #45 