### PR TITLE
Update maven coordinates of compose extension in doc

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -50,7 +50,7 @@ val lab = AndroidColor.valueOf(0f, 1f, 0f, 1f, ColorSpace.get(ColorSpace.Named.C
 
 ```kotlin
 dependencies {
-    implementation("com.github.ajalt.colormath.extensions:colormath-ext-jetpack-compose:$colormathVersion")
+    implementation("com.github.ajalt.colormath:colormath-ext-jetpack-compose::$colormathVersion")
 }
 ```
 


### PR DESCRIPTION
The old coordinates have 3.2.1 as the latest version.
Would be better to keep both artifacts, with the old one being empty, with a dependency on the new one, beyond this PR.

BTW, awesome lib!