### PR TITLE
Add WatchOS Arm32 support.

### DIFF
--- a/colormath/build.gradle.kts
+++ b/colormath/build.gradle.kts
@@ -28,6 +28,7 @@ kotlin {
     tvosArm64()
     tvosSimulatorArm64()
     watchosX64()
+    watchosArm32()
     watchosArm64()
     watchosSimulatorArm64()
 

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -22,6 +22,7 @@ kotlin {
     tvosArm64()
     tvosSimulatorArm64()
     watchosX64()
+    watchosArm32()
     watchosArm64()
     watchosSimulatorArm64()
 


### PR DESCRIPTION
Adds the Arm32 platform of WatchOS (which is used in the series 1-3 watches)

This platform doesn't appear to require any additional code to support, and was previously supported in 3.2.0, but broke in 3.3 when platform targets were added explicitly.
