### PR TITLE
Add support for watchosDeviceArm64

### DIFF
--- a/colormath/build.gradle.kts
+++ b/colormath/build.gradle.kts
@@ -30,6 +30,7 @@ kotlin {
     watchosX64()
     watchosArm32()
     watchosArm64()
+    watchosDeviceArm64()
     watchosSimulatorArm64()
 
     sourceSets {


### PR DESCRIPTION
This is a tiny PR adding support for the new-ish `watchosDeviceArm64` target. Without this target this library can't be used on watchOS as the resulting binaries miss the arm64 target required by Xcode 15 and 16.